### PR TITLE
present all sexp expression the same way in JSON schema

### DIFF
--- a/tests/golden/stack_example_storage.gold
+++ b/tests/golden/stack_example_storage.gold
@@ -14,15 +14,21 @@
         "__main__.stack": [
           {
             "arguments": [
-              "(+ __main__.stack_ptr (- 1))"
+              [
+                "(+ __main__.stack_ptr (- 1))"
+              ]
             ],
-            "value": "11"
+            "value": [
+              "11"
+            ]
           }
         ],
         "__main__.stack_ptr": [
           {
             "arguments": [],
-            "value": "(+ __main__.stack_ptr 1)"
+            "value": [
+              "(+ __main__.stack_ptr 1)"
+            ]
           }
         ]
       }
@@ -42,15 +48,22 @@
         "__main__.stack": [
           {
             "arguments": [
-              "(+ __main__.stack_ptr (- 1))"
+              [
+                "(+ __main__.stack_ptr (- 1))"
+              ]
             ],
-            "value": "(+ (__main__.stack (+ __main__.stack_ptr (- 2)))\n   (__main__.stack (+ __main__.stack_ptr (- 1))))"
+            "value": [
+              "(+ (__main__.stack (+ __main__.stack_ptr (- 2)))",
+              "   (__main__.stack (+ __main__.stack_ptr (- 1))))"
+            ]
           }
         ],
         "__main__.stack_ptr": [
           {
             "arguments": [],
-            "value": "(+ __main__.stack_ptr (- 1))"
+            "value": [
+              "(+ __main__.stack_ptr (- 1))"
+            ]
           }
         ]
       }
@@ -68,15 +81,21 @@
         "__main__.stack": [
           {
             "arguments": [
-              "(+ __main__.stack_ptr (- 1))"
+              [
+                "(+ __main__.stack_ptr (- 1))"
+              ]
             ],
-            "value": "(memory (+ fp (- 3)))"
+            "value": [
+              "(memory (+ fp (- 3)))"
+            ]
           }
         ],
         "__main__.stack_ptr": [
           {
             "arguments": [],
-            "value": "(+ __main__.stack_ptr 1)"
+            "value": [
+              "(+ __main__.stack_ptr 1)"
+            ]
           }
         ]
       }

--- a/tests/golden/storage_vars.gold
+++ b/tests/golden/storage_vars.gold
@@ -24,21 +24,33 @@
         "__main__.balance": [
           {
             "arguments": [
-              "10"
+              [
+                "10"
+              ]
             ],
-            "value": "(__main__.balance 10)"
+            "value": [
+              "(__main__.balance 10)"
+            ]
           },
           {
             "arguments": [
-              "11"
+              [
+                "11"
+              ]
             ],
-            "value": "12"
+            "value": [
+              "12"
+            ]
           },
           {
             "arguments": [
-              "15"
+              [
+                "15"
+              ]
             ],
-            "value": "18"
+            "value": [
+              "18"
+            ]
           }
         ]
       }


### PR DESCRIPTION
before, numeric expressions were represented as a single line

this way, they can be parsed the same way on the checker side