### PR TITLE
Set maximum python version to `3.9`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'poetry'
+      - run: poetry env use 3.7
       - run: poetry install
 
       - name: Check formatting
@@ -45,6 +46,7 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'poetry'
+      - run: poetry env use 3.7
       - run: poetry install
       - run: poetry run pip install pytest
       - name: Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = [ "src/horus/compiler/horus.ebnf" ]
 horus-compile = "horus.compiler.horus_compile:run"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.7,<3.10"
 cairo-lang = "0.9.1"
 marshmallow-dataclass = ">=7.1.0,<8.5.4"
 eth-utils = "^1.2.0"


### PR DESCRIPTION
A dependency `frozendict` (itself a dependency of `cairo-lang`) uses deprecated syntax that was removed in python 3.10, and now raises an `AttributeError`. In particular, it tries to import `Mapping` from `collections`. Thus, this commit explicitly drops support for 3.10.

This commit also fixes the CI to reflect this change. Note that although the CI workflow gives 3.7 as the version prior to this revision, the workflow output suggests it may have been running under 3.10.

* Add `poetry env use` commands to `ci.yml` to fix python versioning mismatch.

```python
ec2-user@ip-172-31-43-130 horus-compile % poetry run horus-compile
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ec2-user/horus-compile/src/horus/compiler/horus_compile.py", line 13, in <module>
    import starkware.cairo.lang.compiler.preprocessor.preprocess_codes
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/cairo/lang/compiler/preprocessor/preprocess_codes.py", line 4, in <module>
    from starkware.cairo.lang.compiler.preprocessor.pass_manager import PassManager, PassManagerContext
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/cairo/lang/compiler/preprocessor/pass_manager.py", line 8, in <module>
    from starkware.cairo.lang.compiler.preprocessor.preprocessor import PreprocessedProgram
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/cairo/lang/compiler/preprocessor/preprocessor.py", line 160, in <module>
    from starkware.starkware_utils.validated_dataclass import ValidatedDataclass
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/starkware_utils/validated_dataclass.py", line 12, in <module>
    from starkware.starkware_utils.validated_fields import Field
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/starkware_utils/validated_fields.py", line 13, in <module>
    from starkware.starkware_utils.marshmallow_dataclass_fields import (
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/starkware/starkware_utils/marshmallow_dataclass_fields.py", line 8, in <module>
    from frozendict import frozendict
  File "/Users/ec2-user/Library/Caches/pypoetry/virtualenvs/horus-compile-szW54r2L-py3.10/lib/python3.10/site-packages/frozendict/__init__.py", line 16, in <module>
    class frozendict(collections.Mapping):
AttributeError: module 'collections' has no attribute 'Mapping'
```