### PR TITLE
Add a hint to error raised when we cannot find an identifier.

### DIFF
--- a/src/horus/compiler/type_checker.py
+++ b/src/horus/compiler/type_checker.py
@@ -461,10 +461,10 @@ def simplify_and_get_type(
             f'Cannot obtain identifier "{expr.name}". Expected a reference but got "{definition.TYPE}"',
             location=expr.location,
             notes=[
-                "hint: Did you try to reference a local variable in a '@pre' condition?",
+                "\033[33mhint: Did you try to reference a local variable in a '@pre' condition?",
                 "hint: Local variables cannot be referenced in '@pre' or '@post'.",
                 "hint:",
-                "hint: Try using an '@assert' within the function body.",
+                "hint: Try using an '@assert' within the function body.\033[0m",
             ],
         )
 


### PR DESCRIPTION
This PR addresses some comments from user testing where we discovered it was unclear whether local variables can be referenced in `@pre` or `@post` (they cannot). We add a nice hint explaining this when the user gets this error message, and a possible solution if they *really* want to assert things about locals.

```console
(horus37) user@computer:~/pkgs/horus-checker$ horus-compile contra.cairo
contra.cairo:1:6: Cannot obtain identifier "y". Expected a reference but got "future"
@pre y == 3
     ^
hint: Did you try to reference a local variable in a '@pre' condition?
hint: Local variables cannot be referenced in '@pre' or '@post'.
hint:
hint: Try using an '@assert' within the function body.
```

This is a trivial change.